### PR TITLE
Modified logic to fetch separate rock lists depending on application …

### DIFF
--- a/src/components/ApplicationViews.jsx
+++ b/src/components/ApplicationViews.jsx
@@ -11,8 +11,14 @@ import { Register } from '../pages/Register.jsx'
 export const ApplicationViews = () => {
     const [rocksState, setRocksState] = useState([])
 
-    const fetchRocksFromAPI = async () => {
-        const response = await fetch("http://localhost:8000/rocks",
+    const fetchRocksFromAPI = async (showAll) => {
+        let url = "http://localhost:8000/rocks"
+
+        if (!showAll) {
+            url = "http://localhost:8000/rocks?owner=current"
+        }
+
+        const response = await fetch( url,
             {
                 headers: {
                     Authorization: `Token ${JSON.parse(localStorage.getItem("rock_token")).token}`
@@ -28,9 +34,23 @@ export const ApplicationViews = () => {
             <Route path="/register" element={<Register />} />
             <Route element={<Authorized />}>
                 <Route path="/" element={<Home />} />
-                <Route path="/allrocks" element={<RockList rocks={rocksState} fetchRocks={fetchRocksFromAPI} />} />
+                <Route path="/allrocks" element={
+                        <RockList 
+                            rocks={rocksState} 
+                            fetchRocks={fetchRocksFromAPI} 
+                            showAll={true} 
+                        />
+                    } 
+                />
                 <Route path="/create" element={<RockForm fetchRocks={fetchRocksFromAPI} />} />
-                <Route path="/mine" element={<RockList rocks={rocksState} fetchRocks={fetchRocksFromAPI} />} />
+                <Route path="/mine" element={
+                        <RockList 
+                            rocks={rocksState} 
+                            fetchRocks={fetchRocksFromAPI} 
+                            showAll={false}
+                        />
+                    } 
+                />
             </Route>
         </Routes>
     </BrowserRouter>

--- a/src/components/RockList.jsx
+++ b/src/components/RockList.jsx
@@ -1,9 +1,20 @@
 import { useEffect } from "react"
 
-export const RockList = ({ rocks, fetchRocks }) => {
+export const RockList = ({ rocks, fetchRocks, showAll }) => {
     useEffect(() => {
-        fetchRocks()
-    }, [])
+        fetchRocks(showAll)
+    }, [showAll])
+
+    const throwRock = async (rockId) => {
+
+        await fetch(`http://localhost:8000/rocks/${rockId}`, {
+            method: 'DELETE',
+            headers: {
+                Authorization: `Token ${JSON.parse(localStorage.getItem("rock_token")).token}`
+            }
+        })
+        await fetchRocks()
+    }
 
     const displayRocks = () => {
         if (rocks && rocks.length) {
@@ -14,6 +25,14 @@ export const RockList = ({ rocks, fetchRocks }) => {
                         </div>
                         <div>
                             In the collection of {rock.user.first_name} {rock.user.last_name}
+                        </div>
+                        <div>
+                            {!showAll && (
+                                <button 
+                                    className="px-3 py-1.5 border-solid bg-red-600 text-red-50 mt-4 hover:text-white hover:bg-black"
+                                    onClick={(e)=> {throwRock(rock.id)}}
+                                >DELETE</button>
+                            )}
                         </div>
                     </div>
                 


### PR DESCRIPTION
…view | Added DELETE functionality for user to delete their own rocks in the 'My Rocks' view

## Changes
- Added 'showAll' boolean to either fetch and render all rocks in the 'All Rocks' view or only rocks belonging to the logged in user in the 'My Rocks' view
- Added Delete button that renders on each rock in the user's 'My Rocks' list and sends a DELETE request to remove the rock from the API & then re-renders the updated 'My Rocks' list with the deleted rock no longer displaying on the page